### PR TITLE
Stdclass contains COLUMN_NAME in uppercase

### DIFF
--- a/src/Xethron/MigrationsGenerator/Generators/FieldGenerator.php
+++ b/src/Xethron/MigrationsGenerator/Generators/FieldGenerator.php
@@ -73,8 +73,8 @@ class FieldGenerator {
 	protected function setEnum(array $fields, $table)
 	{
 		foreach ($this->getEnum($table) as $column) {
-			$fields[$column->column_name]['type'] = 'enum';
-			$fields[$column->column_name]['args'] = str_replace('enum(', 'array(', $column->column_type);
+			$fields[$column->COLUMN_NAME]['type'] = 'enum';
+			$fields[$column->COLUMN_NAME]['args'] = str_replace('enum(', 'array(', $column->COLUMN_TYPE);
 		}
 		return $fields;
 	}


### PR DESCRIPTION
Error with php7.4 and Laravel 7 : Undefined property: stdClass::$column_name