### PR TITLE
Fix issue with double quotes in column name

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Generate Laravel Migrations from an existing database, including indexes and for
 The recommended way to install this is through composer:
 
 ```bash
-composer require oscarafdev/migrations-generator
+composer require oscarafdev/migrations-generator --dev
 ```
 
 In Laravel 5.5+ the service providers will automatically get registered. 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,10 @@ Thanks to Jeffrey Way for his amazing Laravel-4-Generators package. This package
 ## Contributors
 
 Bernhard Breytenbach ([@BBreyten](https://twitter.com/BBreyten))
+
 Oscar Fernandez ([@oscarafdev](https://www.linkedin.com/in/oscarafdev/))
+
+ofernandez@sofrecom.com.ar
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Laravel Migrations Generator Laravel 6+
+# Laravel Migrations Generator Laravel 5/6/7 +
 
 
 [![Latest Stable Version](https://poser.pugx.org/oscarafdev/migrations-generator/v/stable)](https://packagist.org/packages/oscarafdev/migrations-generator)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Generate Laravel Migrations from an existing database, including indexes and for
 The recommended way to install this is through composer:
 
 ```bash
-composer require oscarafdev/migrations-generator 2.0.16
+composer require oscarafdev/migrations-generator 2.0.17
 ```
 
 In Laravel 5.5+ the service providers will automatically get registered. 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Thanks to Jeffrey Way for his amazing Laravel-4-Generators package. This package
 ## Contributors
 
 Bernhard Breytenbach ([@BBreyten](https://twitter.com/BBreyten))
+Oscar Fernandez ([@oscarafdev](https://www.linkedin.com/in/oscarafdev/))
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Generate Laravel Migrations from an existing database, including indexes and for
 The recommended way to install this is through composer:
 
 ```bash
-composer require oscarafdev/migrations-generator 2.0.9
+composer require oscarafdev/migrations-generator 2.0.13
 ```
 
 In Laravel 5.5+ the service providers will automatically get registered. 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Generate Laravel Migrations from an existing database, including indexes and for
 The recommended way to install this is through composer:
 
 ```bash
-composer require oscarafdev/migrations-generator 2.0.13
+composer require oscarafdev/migrations-generator 2.0.15
 ```
 
 In Laravel 5.5+ the service providers will automatically get registered. 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-# Laravel Migrations Generator
+# Laravel Migrations Generator Laravel 6
 
-[![Build Status](https://travis-ci.org/Xethron/migrations-generator.svg)](https://travis-ci.org/Xethron/migrations-generator)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/Xethron/migrations-generator/badges/quality-score.png?s=41d919c6d044749cb8575bb936efbddc4cebc0d8)](https://scrutinizer-ci.com/g/Xethron/migrations-generator/)
 [![Latest Stable Version](https://poser.pugx.org/xethron/migrations-generator/v/stable.png)](https://packagist.org/packages/xethron/migrations-generator)
 [![Total Downloads](https://poser.pugx.org/xethron/migrations-generator/downloads.png)](https://packagist.org/packages/xethron/migrations-generator)
@@ -8,59 +7,16 @@
 
 Generate Laravel Migrations from an existing database, including indexes and foreign keys!
 
-## Upgrading to Laravel 5.4
 
-Please note that the Laravel 4 Generator edits have been moved to `https://github.com/xethron/Laravel-4-Generators.git` to update compatibility.
-
-## Laravel 5 installation
+## Laravel 6 installation
 
 The recommended way to install this is through composer:
 
 ```bash
-composer require --dev "xethron/migrations-generator"
+composer require --dev "oscarafdev/migrations-generator"
 ```
 
-In Laravel 5.5 the service providers will automatically get registered. 
-
-In older versions of the framework edit `config/app.php` and add this to providers section:
-
-```php
-Way\Generators\GeneratorsServiceProvider::class,
-Xethron\MigrationsGenerator\MigrationsGeneratorServiceProvider::class,
-```
-If you want this lib only for dev, you can add the following code to your `app/Providers/AppServiceProvider.php` file, within the `register()` method:
-
-```php
-public function register()
-{
-    if ($this->app->environment() !== 'production') {
-        $this->app->register(\Way\Generators\GeneratorsServiceProvider::class);
-        $this->app->register(\Xethron\MigrationsGenerator\MigrationsGeneratorServiceProvider::class);
-    }
-    // ...
-}
-```
-
-Notes:
-* Thanks to @jamisonvalenta, you can now generate Migrations in Laravel 5!
-* `feature/laravel-five-stable` was forked from `way/generators` `3.0.3` and was made Laravel `5.0` ready. Jeffrey Way has discontinued support for Laravel 5, so the other `artisan generate:` commands may not have been made `5.0` compatible.  Investigate the `artisan make:` commands for substitutes, contribute to Laravel to extend generation support, or fix it and submit a PR to `jamisonvalenta/feature/laravel-five-stable`.
-
-## Laravel 4 installation
-
-Run the following composer command:
-
-```bash
-composer require --dev "xethron/migrations-generator:~1.3.0"
-```
-
-Next, add the following service providers:
-
-```php
-'Way\Generators\GeneratorsServiceProvider',
-'Xethron\MigrationsGenerator\MigrationsGeneratorServiceProvider',
-```
-
-And you're set. To double check if its working, run `php artisan`, and look for the command `migrate:generate`
+In Laravel 5.5+ the service providers will automatically get registered. 
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Laravel Migrations Generator Laravel 6
 
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/Xethron/migrations-generator/badges/quality-score.png?s=41d919c6d044749cb8575bb936efbddc4cebc0d8)](https://scrutinizer-ci.com/g/Xethron/migrations-generator/)
-[![Latest Stable Version](https://poser.pugx.org/xethron/migrations-generator/v/stable.png)](https://packagist.org/packages/xethron/migrations-generator)
-[![Total Downloads](https://poser.pugx.org/xethron/migrations-generator/downloads.png)](https://packagist.org/packages/xethron/migrations-generator)
-[![License](https://poser.pugx.org/xethron/migrations-generator/license.png)](https://packagist.org/packages/xethron/migrations-generator)
+[![Latest Stable Version](https://poser.pugx.org/oscarafdev/migrations-generator/v/stable)](https://packagist.org/packages/oscarafdev/migrations-generator)
+[![Total Downloads](https://poser.pugx.org/oscarafdev/migrations-generator/downloads)](https://packagist.org/packages/oscarafdev/migrations-generator)
+[![License](https://poser.pugx.org/oscarafdev/migrations-generator/license)](https://packagist.org/packages/oscarafdev/migrations-generator)
 
 Generate Laravel Migrations from an existing database, including indexes and foreign keys!
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Laravel Migrations Generator Laravel 6
+# Laravel Migrations Generator Laravel 6+
 
 
 [![Latest Stable Version](https://poser.pugx.org/oscarafdev/migrations-generator/v/stable)](https://packagist.org/packages/oscarafdev/migrations-generator)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Generate Laravel Migrations from an existing database, including indexes and for
 The recommended way to install this is through composer:
 
 ```bash
-composer require oscarafdev/migrations-generator 2.0.18
+composer require oscarafdev/migrations-generator 2.0.19
 ```
 
 In Laravel 5.5+ the service providers will automatically get registered. 
@@ -35,6 +35,9 @@ Check out Chung Tran's blog post for a quick step by step introduction: [Generat
 ## Changelog
 
 Changelog for Laravel Migrations Generator
+
+### May 2020: v2.0.19
+* Support for Laravel 7
 
 ### 10 December 2019: v2.0.12
 * Support for Laravel 6

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Laravel Migrations Generator Laravel 6
 
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/Xethron/migrations-generator/badges/quality-score.png?s=41d919c6d044749cb8575bb936efbddc4cebc0d8)](https://scrutinizer-ci.com/g/Xethron/migrations-generator/)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/OscarAFDev/migrations-generator/badges/quality-score.png?s=41d919c6d044749cb8575bb936efbddc4cebc0d8)](https://scrutinizer-ci.com/g/OscarAFDev/migrations-generator/)
 [![Latest Stable Version](https://poser.pugx.org/oscarafdev/migrations-generator/v/stable)](https://packagist.org/packages/oscarafdev/migrations-generator)
 [![Total Downloads](https://poser.pugx.org/oscarafdev/migrations-generator/downloads)](https://packagist.org/packages/oscarafdev/migrations-generator)
 [![License](https://poser.pugx.org/oscarafdev/migrations-generator/license)](https://packagist.org/packages/oscarafdev/migrations-generator)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Generate Laravel Migrations from an existing database, including indexes and for
 The recommended way to install this is through composer:
 
 ```bash
-composer require oscarafdev/migrations-generator 2.0.17
+composer require oscarafdev/migrations-generator 2.0.18
 ```
 
 In Laravel 5.5+ the service providers will automatically get registered. 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ Check out Chung Tran's blog post for a quick step by step introduction: [Generat
 
 Changelog for Laravel Migrations Generator
 
+### Ago 2020: v2.0.23
+* Added support for precisions in timestamp.
+* Fixed an issue with the text type.
+* Fixed other reported bugs
+
 ### May 2020: v2.0.19
 * Support for Laravel 7
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Laravel Migrations Generator Laravel 6
 
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/OscarAFDev/migrations-generator/badges/quality-score.png?s=41d919c6d044749cb8575bb936efbddc4cebc0d8)](https://scrutinizer-ci.com/g/OscarAFDev/migrations-generator/)
+
 [![Latest Stable Version](https://poser.pugx.org/oscarafdev/migrations-generator/v/stable)](https://packagist.org/packages/oscarafdev/migrations-generator)
 [![Total Downloads](https://poser.pugx.org/oscarafdev/migrations-generator/downloads)](https://packagist.org/packages/oscarafdev/migrations-generator)
 [![License](https://poser.pugx.org/oscarafdev/migrations-generator/license)](https://packagist.org/packages/oscarafdev/migrations-generator)
@@ -13,7 +13,7 @@ Generate Laravel Migrations from an existing database, including indexes and for
 The recommended way to install this is through composer:
 
 ```bash
-composer require --dev "oscarafdev/migrations-generator"
+composer require oscarafdev/migrations-generator 2.0.9
 ```
 
 In Laravel 5.5+ the service providers will automatically get registered. 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Check out Chung Tran's blog post for a quick step by step introduction: [Generat
 
 Changelog for Laravel Migrations Generator
 
+### 10 December 2019: v2.0.12
+* Support for Laravel 6
+
 ### 20 November 2016: v2.0.0
 * Support for Laravel 5
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Generate Laravel Migrations from an existing database, including indexes and for
 The recommended way to install this is through composer:
 
 ```bash
-composer require oscarafdev/migrations-generator 2.0.19
+composer require oscarafdev/migrations-generator
 ```
 
 In Laravel 5.5+ the service providers will automatically get registered. 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Generate Laravel Migrations from an existing database, including indexes and for
 The recommended way to install this is through composer:
 
 ```bash
-composer require oscarafdev/migrations-generator 2.0.15
+composer require oscarafdev/migrations-generator 2.0.16
 ```
 
 In Laravel 5.5+ the service providers will automatically get registered. 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	],
 	"require": {
 		"php": ">=5.4.0",
-		"illuminate/support": ">=4.1|^6.0",
+		"illuminate/support": "^6.0",
 		"xethron/laravel-4-generators": "~3.1.0",
 		"doctrine/dbal": "~2.4"
 	},

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	],
 	"require": {
 		"php": "^7.2",
-		"illuminate/support": ">=6.0",
+		"illuminate/support": "^6.0",
 		"oscarafdev/laravel-4-generators": "~3.1.2",
 		"doctrine/dbal": "~2.10"
 	},

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,12 @@
 {
-	"name": "xethron/migrations-generator",
+	"name": "oscarafdev/migrations-generator",
 	"description": "Generates Laravel Migrations from an existing database",
 	"keywords": ["laravel", "migration", "generator", "migrations", "artisan"],
 	"license": "MIT",
 	"authors": [
 		{
-			"name": "Bernhard Breytenbach",
-			"email": "bernhard@coffeecode.co.za"
+			"name": "Oscar Fernandez",
+			"email": "oscarafdev@gmail.com"
 		}
 	],
 	"require": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	],
 	"require": {
 		"php": "^7.2",
-		"illuminate/support": "^6.0",
+		"illuminate/support": "^6.0 || ^7.0",
 		"oscarafdev/laravel-4-generators": "~3.1.4",
 		"doctrine/dbal": "~2.10"
 	},

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	"require": {
 		"php": "^7.2",
 		"illuminate/support": "^6.0",
-		"oscarafdev/laravel-4-generators": "~3.1.2",
+		"oscarafdev/laravel-4-generators": "~3.1.4",
 		"doctrine/dbal": "~2.10"
 	},
 	"autoload": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		"doctrine/dbal": "~2.10"
 	},
 	"autoload": {
-		"psr-0": {
+		"psr-4": {
 			"OscarAFDev\\MigrationsGenerator": "src/"
 		}
 	},

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	"require": {
 		"php": "^7.2",
 		"illuminate/support": "^6.0",
-		"xethron/laravel-4-generators": "~3.1.0",
+		"OscarAFDev/laravel-4-generators": "~3.1.0",
 		"doctrine/dbal": "~2.4"
 	},
 	"autoload": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	],
 	"require": {
 		"php": "^7.2",
-		"illuminate/support": "^6.0 || ^7.0",
+		"illuminate/support": "^5.0 || ^6.0 || ^7.0",
 		"oscarafdev/laravel-4-generators": "~3.1.5",
 		"doctrine/dbal": "~2.10"
 	},

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
 	],
 	"require": {
 		"php": "^7.2",
-		"illuminate/support": "^6.0",
+		"illuminate/support": ">=6.0",
 		"oscarafdev/laravel-4-generators": "~3.1.2",
-		"doctrine/dbal": "~2.4"
+		"doctrine/dbal": "~2.10"
 	},
 	"autoload": {
 		"psr-0": {
@@ -21,10 +21,10 @@
 		}
 	},
 	"require-dev": {
-		"phpunit/phpunit": ">=4.0.0|^8.0",
-		"mockery/mockery": ">=0.9.0",
-		"illuminate/cache": ">=4.1.0",
-		"illuminate/console": ">=4.1.0"
+		"phpunit/phpunit": ">=8.0",
+		"mockery/mockery": ">=1.0.3",
+		"illuminate/cache": ">=6.0",
+		"illuminate/console": ">=6.0"
 	},
 	"extra": {
 		"laravel": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		"doctrine/dbal": "~2.10"
 	},
 	"autoload": {
-		"psr-4": {
+		"psr-0": {
 			"OscarAFDev\\MigrationsGenerator": "src/"
 		}
 	},

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 	},
 	"autoload": {
 		"psr-0": {
-			"Xethron\\MigrationsGenerator": "src/"
+			"OscarAFDev\\MigrationsGenerator": "src/"
 		}
 	},
 	"require-dev": {
@@ -30,7 +30,7 @@
 		"laravel": {
 			"providers": [
 				"Way\\Generators\\GeneratorsServiceProvider",
-				"Xethron\\MigrationsGenerator\\MigrationsGeneratorServiceProvider"
+				"OscarAFDev\\MigrationsGenerator\\MigrationsGeneratorServiceProvider"
 			]
 		}
 	}

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		}
 	],
 	"require": {
-		"php": ">=5.4.0",
+		"php": "^7.2",
 		"illuminate/support": "^6.0",
 		"xethron/laravel-4-generators": "~3.1.0",
 		"doctrine/dbal": "~2.4"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	"require": {
 		"php": "^7.2",
 		"illuminate/support": "^6.0 || ^7.0",
-		"oscarafdev/laravel-4-generators": "~3.1.4",
+		"oscarafdev/laravel-4-generators": "~3.1.5",
 		"doctrine/dbal": "~2.10"
 	},
 	"autoload": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	"require": {
 		"php": "^7.2",
 		"illuminate/support": "^6.0",
-		"OscarAFDev/laravel-4-generators": "~3.1.0",
+		"xethron/laravel-4-generators": "~3.1.0",
 		"doctrine/dbal": "~2.4"
 	},
 	"autoload": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	"require": {
 		"php": "^7.2",
 		"illuminate/support": "^6.0",
-		"xethron/laravel-4-generators": "~3.1.0",
+		"oscarafdev/laravel-4-generators": "~3.1.2",
 		"doctrine/dbal": "~2.4"
 	},
 	"autoload": {

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
 		}
 	],
 	"require": {
-		"php": "^7.2",
+		"php": "^7.0",
 		"illuminate/support": "^5.0 || ^6.0 || ^7.0",
-		"oscarafdev/laravel-4-generators": "~3.1.5",
+		"oscarafdev/laravel-4-generators": "^3.1",
 		"doctrine/dbal": "~2.10"
 	},
 	"autoload": {

--- a/src/OscarAFDev/MigrationsGenerator/Generators/FieldGenerator.php
+++ b/src/OscarAFDev/MigrationsGenerator/Generators/FieldGenerator.php
@@ -73,8 +73,8 @@ class FieldGenerator {
 	protected function setEnum(array $fields, $table)
 	{
 		foreach ($this->getEnum($table) as $column) {
-			$fields[$column->column_name]['type'] = 'enum';
-			$fields[$column->column_name]['args'] = str_replace('enum(', 'array(', $column->column_type);
+			$fields[$column->COLUMN_NAME]['type'] = 'enum';
+			$fields[$column->COLUMN_NAME]['args'] = str_replace('enum(', 'array(', $column->COLUMN_TYPE);
 		}
 		return $fields;
 	}

--- a/src/OscarAFDev/MigrationsGenerator/Generators/FieldGenerator.php
+++ b/src/OscarAFDev/MigrationsGenerator/Generators/FieldGenerator.php
@@ -1,4 +1,4 @@
-<?php namespace Xethron\MigrationsGenerator\Generators;
+<?php namespace OscarAFDev\MigrationsGenerator\Generators;
 
 use DB;
 

--- a/src/OscarAFDev/MigrationsGenerator/Generators/FieldGenerator.php
+++ b/src/OscarAFDev/MigrationsGenerator/Generators/FieldGenerator.php
@@ -131,10 +131,10 @@ class FieldGenerator {
 					$type = 'softDeletes';
 					$name = '';
 				} elseif ($name == 'created_at' and isset($fields['updated_at'])) {
-					$fields['updated_at'] = ['field' => '', 'type' => 'timestamps'];
+					$fields['updated_at'] = ['field' => '', 'type' => 'timestamps', 'args' => $column->getPrecision()];
 					continue;
 				} elseif ($name == 'updated_at' and isset($fields['created_at'])) {
-					$fields['created_at'] = ['field' => '', 'type' => 'timestamps'];
+					$fields['created_at'] = ['field' => '', 'type' => 'timestamps', 'args' => $column->getPrecision()];
 					continue;
 				}
 			} elseif (in_array($type, ['decimal', 'float', 'double'])) {

--- a/src/OscarAFDev/MigrationsGenerator/Generators/FieldGenerator.php
+++ b/src/OscarAFDev/MigrationsGenerator/Generators/FieldGenerator.php
@@ -73,8 +73,8 @@ class FieldGenerator {
 	protected function setEnum(array $fields, $table)
 	{
 		foreach ($this->getEnum($table) as $column) {
-			$fields[$column->COLUMN_NAME]['type'] = 'enum';
-			$fields[$column->COLUMN_NAME]['args'] = str_replace('enum(', 'array(', $column->COLUMN_TYPE);
+			$fields[$column->column_name]['type'] = 'enum';
+			$fields[$column->column_name]['args'] = str_replace('enum(', 'array(', $column->column_type);
 		}
 		return $fields;
 	}

--- a/src/OscarAFDev/MigrationsGenerator/Generators/FieldGenerator.php
+++ b/src/OscarAFDev/MigrationsGenerator/Generators/FieldGenerator.php
@@ -71,14 +71,19 @@ class FieldGenerator {
 	 * @param string $table
 	 * @return array
 	 */
-	 protected function setEnum(array $fields, $table)
-	{
-		foreach ($this->getEnum($table) as $column) {
-			$fields[$column->COLUMN_NAME]['type'] = 'enum';
-			$fields[$column->COLUMN_NAME]['args'] = str_replace('enum(', 'array(', $column->COLUMN_TYPE);
-		}
-		return $fields;
-	}
+    protected function setEnum(array $fields, $table)
+    {
+        foreach ($this->getEnum($table) as $column) {
+            if (isset($column->COLUMN_NAME)) {
+                $fields[$column->COLUMN_NAME]['type'] = 'enum';
+                $fields[$column->COLUMN_NAME]['args'] = str_replace('enum(', 'array(', $column->COLUMN_TYPE);
+            } elseif (isset($column->column_name)) {
+                $fields[$column->column_name]['type'] = 'enum';
+                $fields[$column->column_name]['args'] = str_replace('enum(', 'array(', $column->column_type);
+            }
+        }
+        return $fields;
+    }
 
 	/**
 	 * @param \Doctrine\DBAL\Schema\Column[] $columns

--- a/src/OscarAFDev/MigrationsGenerator/Generators/FieldGenerator.php
+++ b/src/OscarAFDev/MigrationsGenerator/Generators/FieldGenerator.php
@@ -48,6 +48,7 @@ class FieldGenerator {
 	 * @param string $table
 	 * @return array
 	 */
+	
 	protected function getEnum($table)
 	{
 		try {
@@ -70,11 +71,11 @@ class FieldGenerator {
 	 * @param string $table
 	 * @return array
 	 */
-	protected function setEnum(array $fields, $table)
+	 protected function setEnum(array $fields, $table)
 	{
 		foreach ($this->getEnum($table) as $column) {
-			$fields[$column->column_name]['type'] = 'enum';
-			$fields[$column->column_name]['args'] = str_replace('enum(', 'array(', $column->column_type);
+			$fields[$column->COLUMN_NAME]['type'] = 'enum';
+			$fields[$column->COLUMN_NAME]['args'] = str_replace('enum(', 'array(', $column->COLUMN_TYPE);
 		}
 		return $fields;
 	}

--- a/src/OscarAFDev/MigrationsGenerator/Generators/ForeignKeyGenerator.php
+++ b/src/OscarAFDev/MigrationsGenerator/Generators/ForeignKeyGenerator.php
@@ -1,4 +1,4 @@
-<?php namespace Xethron\MigrationsGenerator\Generators;
+<?php namespace OscarAFDev\MigrationsGenerator\Generators;
 
 class ForeignKeyGenerator {
 

--- a/src/OscarAFDev/MigrationsGenerator/Generators/IndexGenerator.php
+++ b/src/OscarAFDev/MigrationsGenerator/Generators/IndexGenerator.php
@@ -1,4 +1,4 @@
-<?php namespace Xethron\MigrationsGenerator\Generators;
+<?php namespace OscarAFDev\MigrationsGenerator\Generators;
 
 
 class IndexGenerator {

--- a/src/OscarAFDev/MigrationsGenerator/Generators/SchemaGenerator.php
+++ b/src/OscarAFDev/MigrationsGenerator/Generators/SchemaGenerator.php
@@ -1,4 +1,4 @@
-<?php namespace Xethron\MigrationsGenerator\Generators;
+<?php namespace OscarAFDev\MigrationsGenerator\Generators;
 
 use Illuminate\Support\Facades\DB;
 

--- a/src/OscarAFDev/MigrationsGenerator/MigrateGenerateCommand.php
+++ b/src/OscarAFDev/MigrationsGenerator/MigrateGenerateCommand.php
@@ -325,7 +325,7 @@ class MigrateGenerateCommand extends GeneratorCommand {
 		}
 
 		return [
-			'CLASS' => ucwords(\Str::camel($this->migrationName)),
+			'CLASS' => ucwords(Str::camel($this->migrationName)),
 			'UP'    => $up,
 			'DOWN'  => $down
 		];

--- a/src/OscarAFDev/MigrationsGenerator/MigrateGenerateCommand.php
+++ b/src/OscarAFDev/MigrationsGenerator/MigrateGenerateCommand.php
@@ -14,6 +14,7 @@ use OscarAFDev\MigrationsGenerator\Syntax\AddToTable;
 use OscarAFDev\MigrationsGenerator\Syntax\DroppedTable;
 use OscarAFDev\MigrationsGenerator\Syntax\AddForeignKeysToTable;
 use OscarAFDev\MigrationsGenerator\Syntax\RemoveForeignKeysFromTable;
+use Illuminate\Support\Str;
 
 use Illuminate\Contracts\Config\Repository as Config;
 

--- a/src/OscarAFDev/MigrationsGenerator/MigrateGenerateCommand.php
+++ b/src/OscarAFDev/MigrationsGenerator/MigrateGenerateCommand.php
@@ -240,7 +240,7 @@ class MigrateGenerateCommand extends GeneratorCommand {
 
 		foreach ( $tables as $table ) {
 			$this->table = $table;
-			$this->migrationName = 'create_'. $this->table .'_table';
+			$this->migrationName = 'create_' . str_replace('.', '', $this->table) . '_table';
 			$this->fields = $this->schemaGenerator->getFields( $this->table );
 
 			$this->generate();
@@ -325,7 +325,7 @@ class MigrateGenerateCommand extends GeneratorCommand {
 		}
 
 		return [
-			'CLASS' => ucwords(Str::camel(str_replace('.', '', $this->migrationName))),
+			'CLASS' => ucwords(Str::camel($this->migrationName)),
 			'UP'    => $up,
 			'DOWN'  => $down
 		];

--- a/src/OscarAFDev/MigrationsGenerator/MigrateGenerateCommand.php
+++ b/src/OscarAFDev/MigrationsGenerator/MigrateGenerateCommand.php
@@ -396,7 +396,7 @@ class MigrateGenerateCommand extends GeneratorCommand {
 		$excludes = ['migrations'];
 		$ignore = $this->option('ignore');
 		if ( ! empty($ignore)) {
-			return array_merge($excludes, explode(',', $ignore));
+			return array_merge($excludes, preg_split('/[,\s]+/', ignore));
 		}
 
 		return $excludes;

--- a/src/OscarAFDev/MigrationsGenerator/MigrateGenerateCommand.php
+++ b/src/OscarAFDev/MigrationsGenerator/MigrateGenerateCommand.php
@@ -325,7 +325,7 @@ class MigrateGenerateCommand extends GeneratorCommand {
 		}
 
 		return [
-			'CLASS' => ucwords(Str::camel($this->migrationName)),
+			'CLASS' => ucwords(Str::camel(str_replace('.', '', $this->migrationName))),
 			'UP'    => $up,
 			'DOWN'  => $down
 		];

--- a/src/OscarAFDev/MigrationsGenerator/MigrateGenerateCommand.php
+++ b/src/OscarAFDev/MigrationsGenerator/MigrateGenerateCommand.php
@@ -1,4 +1,4 @@
-<?php namespace Xethron\MigrationsGenerator;
+<?php namespace OscarAFDev\MigrationsGenerator;
 
 use Way\Generators\Commands\GeneratorCommand;
 use Symfony\Component\Console\Input\InputOption;
@@ -9,11 +9,11 @@ use Way\Generators\Filesystem\Filesystem;
 use Way\Generators\Compilers\TemplateCompiler;
 use Illuminate\Database\Migrations\MigrationRepositoryInterface;
 
-use Xethron\MigrationsGenerator\Generators\SchemaGenerator;
-use Xethron\MigrationsGenerator\Syntax\AddToTable;
-use Xethron\MigrationsGenerator\Syntax\DroppedTable;
-use Xethron\MigrationsGenerator\Syntax\AddForeignKeysToTable;
-use Xethron\MigrationsGenerator\Syntax\RemoveForeignKeysFromTable;
+use OscarAFDev\MigrationsGenerator\Generators\SchemaGenerator;
+use OscarAFDev\MigrationsGenerator\Syntax\AddToTable;
+use OscarAFDev\MigrationsGenerator\Syntax\DroppedTable;
+use OscarAFDev\MigrationsGenerator\Syntax\AddForeignKeysToTable;
+use OscarAFDev\MigrationsGenerator\Syntax\RemoveForeignKeysFromTable;
 
 use Illuminate\Contracts\Config\Repository as Config;
 
@@ -52,7 +52,7 @@ class MigrateGenerateCommand extends GeneratorCommand {
 	protected $config;
 
 	/**
-	 * @var \Xethron\MigrationsGenerator\Generators\SchemaGenerator
+	 * @var \OscarAFDev\MigrationsGenerator\Generators\SchemaGenerator
 	 */
 	protected $schemaGenerator;
 

--- a/src/OscarAFDev/MigrationsGenerator/MigrateGenerateCommand.php
+++ b/src/OscarAFDev/MigrationsGenerator/MigrateGenerateCommand.php
@@ -324,7 +324,7 @@ class MigrateGenerateCommand extends GeneratorCommand {
 		}
 
 		return [
-			'CLASS' => ucwords(camel_case($this->migrationName)),
+			'CLASS' => ucwords(\Str::camel($this->migrationName)),
 			'UP'    => $up,
 			'DOWN'  => $down
 		];

--- a/src/OscarAFDev/MigrationsGenerator/MigrateGenerateCommand.php
+++ b/src/OscarAFDev/MigrationsGenerator/MigrateGenerateCommand.php
@@ -396,7 +396,7 @@ class MigrateGenerateCommand extends GeneratorCommand {
 		$excludes = ['migrations'];
 		$ignore = $this->option('ignore');
 		if ( ! empty($ignore)) {
-			return array_merge($excludes, preg_split('/[,\s]+/', ignore));
+			return array_merge($excludes, preg_split('/[,\s]+/', $ignore));
 		}
 
 		return $excludes;

--- a/src/OscarAFDev/MigrationsGenerator/MigrationsGeneratorServiceProvider.php
+++ b/src/OscarAFDev/MigrationsGenerator/MigrationsGeneratorServiceProvider.php
@@ -1,4 +1,4 @@
-<?php namespace Xethron\MigrationsGenerator;
+<?php namespace OscarAFDev\MigrationsGenerator;
 
 use Illuminate\Support\ServiceProvider;
 

--- a/src/OscarAFDev/MigrationsGenerator/Syntax/AddForeignKeysToTable.php
+++ b/src/OscarAFDev/MigrationsGenerator/Syntax/AddForeignKeysToTable.php
@@ -1,8 +1,8 @@
-<?php namespace Xethron\MigrationsGenerator\Syntax;
+<?php namespace OscarAFDev\MigrationsGenerator\Syntax;
 
 /**
  * Class AddForeignKeysToTable
- * @package Xethron\MigrationsGenerator\Syntax
+ * @package OscarAFDev\MigrationsGenerator\Syntax
  */
 class AddForeignKeysToTable extends Table {
 

--- a/src/OscarAFDev/MigrationsGenerator/Syntax/AddToTable.php
+++ b/src/OscarAFDev/MigrationsGenerator/Syntax/AddToTable.php
@@ -45,7 +45,7 @@ class AddToTable extends Table {
             }
             else {
                 $output = sprintf(
-                    "\$table->%s('%s', %s)",
+                    "\$table->%s(%s, %s)",
                     $type,
                     $property,
                     $field['args']

--- a/src/OscarAFDev/MigrationsGenerator/Syntax/AddToTable.php
+++ b/src/OscarAFDev/MigrationsGenerator/Syntax/AddToTable.php
@@ -34,14 +34,24 @@ class AddToTable extends Table {
 
 		// If we have args, then it needs
 		// to be formatted a bit differently
-		if (isset($field['args'])) {
-			$output = sprintf(
-				"\$table->%s(%s, %s)",
-				$type,
-				$property,
-				$field['args']
-			);
-		}
+        if (isset($field['args']) && $type !== 'text')
+        {
+            if ($property == '' || $property == null) {
+                $output = sprintf(
+                    "\$table->%s(%s)",
+                    $type,
+                    $field['args']
+                );
+            }
+            else {
+                $output = sprintf(
+                    "\$table->%s('%s', %s)",
+                    $type,
+                    $property,
+                    $field['args']
+                );
+            }
+        }
 		if (isset($field['decorators'])) {
 			$output .= $this->addDecorators( $field['decorators'] );
 		}

--- a/src/OscarAFDev/MigrationsGenerator/Syntax/AddToTable.php
+++ b/src/OscarAFDev/MigrationsGenerator/Syntax/AddToTable.php
@@ -1,8 +1,8 @@
-<?php namespace Xethron\MigrationsGenerator\Syntax;
+<?php namespace OscarAFDev\MigrationsGenerator\Syntax;
 
 /**
  * Class AddToTable
- * @package Xethron\MigrationsGenerator\Syntax
+ * @package OscarAFDev\MigrationsGenerator\Syntax
  */
 class AddToTable extends Table {
 

--- a/src/OscarAFDev/MigrationsGenerator/Syntax/DroppedTable.php
+++ b/src/OscarAFDev/MigrationsGenerator/Syntax/DroppedTable.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Xethron\MigrationsGenerator\Syntax;
+namespace OscarAFDev\MigrationsGenerator\Syntax;
 
 class DroppedTable
 {

--- a/src/OscarAFDev/MigrationsGenerator/Syntax/RemoveForeignKeysFromTable.php
+++ b/src/OscarAFDev/MigrationsGenerator/Syntax/RemoveForeignKeysFromTable.php
@@ -1,8 +1,8 @@
-<?php namespace Xethron\MigrationsGenerator\Syntax;
+<?php namespace OscarAFDev\MigrationsGenerator\Syntax;
 
 /**
  * Class RemoveForeignKeysFromTable
- * @package Xethron\MigrationsGenerator\Syntax
+ * @package OscarAFDev\MigrationsGenerator\Syntax
  */
 class RemoveForeignKeysFromTable extends Table {
 

--- a/src/OscarAFDev/MigrationsGenerator/Syntax/Table.php
+++ b/src/OscarAFDev/MigrationsGenerator/Syntax/Table.php
@@ -1,8 +1,8 @@
-<?php namespace Xethron\MigrationsGenerator\Syntax;
+<?php namespace OscarAFDev\MigrationsGenerator\Syntax;
 
 /**
  * Class Table
- * @package Xethron\MigrationsGenerator\Syntax
+ * @package OscarAFDev\MigrationsGenerator\Syntax
  */
 abstract class Table extends \Way\Generators\Syntax\Table{
 

--- a/tests/OscarAFDev/MigrationsGenerator/MigrationsGeneratorServiceProviderTest.php
+++ b/tests/OscarAFDev/MigrationsGenerator/MigrationsGeneratorServiceProviderTest.php
@@ -1,4 +1,4 @@
-<?php namespace Xethron\MigrationsGenerator;
+<?php namespace OscarAFDev\MigrationsGenerator;
 
 use Mockery;
 use PHPUnit_Framework_TestCase;
@@ -87,7 +87,7 @@ class MigrationsGeneratorServiceProviderTest extends PHPUnit_Framework_TestCase 
             );
 
           $this->assertInstanceOf(
-            'Xethron\MigrationsGenerator\MigrateGenerateCommand',
+            'OscarAFDev\MigrationsGenerator\MigrateGenerateCommand',
             $callback($mock)
           );
 
@@ -128,7 +128,7 @@ class MigrationsGeneratorServiceProviderTest extends PHPUnit_Framework_TestCase 
       $app_mock = $this->get_app_mock();
     }
 
-    return Mockery::mock('Xethron\MigrationsGenerator\MigrationsGeneratorServiceProvider', [
+    return Mockery::mock('OscarAFDev\MigrationsGenerator\MigrationsGeneratorServiceProvider', [
         $app_mock
       ])
       ->shouldAllowMockingProtectedMethods()

--- a/tests/OscarAFDev/MigrationsGenerator/MigrationsGeneratorTest.php
+++ b/tests/OscarAFDev/MigrationsGenerator/MigrationsGeneratorTest.php
@@ -1,4 +1,4 @@
-<?php namespace Xethron\MigrationsGenerator;
+<?php namespace OscarAFDev\MigrationsGenerator;
 
 use Mockery;
 use PHPUnit_Framework_TestCase;


### PR DESCRIPTION
When a column have not a default length or is ENUM type, a double quotes was added in the name.

Laravel 7.28.3
PHP 7.3.18